### PR TITLE
Support elements and jQuery objects for processing

### DIFF
--- a/jquery.appear.js
+++ b/jquery.appear.js
@@ -18,7 +18,6 @@
     force_appear: false
   }
   var $window = $(window);
-  var $document = $(document);
 
   var $prior_appeared;
 


### PR DESCRIPTION
Currently we only support textual selectors.

These changes allow to do something like this:

``` javascript
$element.appear() // $element is a jQuery object previously selected
```

This is useful in a scenario were the `$element` is not selected in the same place were you are attaching the plugin e.g. working with an MVC pattern.
