### PR TITLE
Uncaught TypeError: Object #<HTMLDocument> has no method 'filter'

### DIFF
--- a/jquery.appear.js
+++ b/jquery.appear.js
@@ -23,7 +23,7 @@
 
   function process() {
     check_lock = false;
-    for (var index in selectors) {
+    for (var index = 0; index < selectors.length; index++) {
       var $appeared = $(selectors[index]).filter(function() {
         return $(this).is(':appeared');
       });


### PR DESCRIPTION
Getting error:

   Uncaught TypeError: Object #<HTMLDocument> has no method 'filter' 

When I've added function to Array.prototype for IE8 JavaScript compatibility, e.g.

```
if (!Array.prototype.indexOf) {
  Array.prototype.indexOf = function (searchElement /*, fromIndex */ ) {
    "use strict";
    if (this == null) {
    ...
  };
}
```

[from https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/indexOf?redirectlocale=en-US&redirectslug=JavaScript%2FReference%2FGlobal_Objects%2FArray%2FindexOf]

This is because [jquery.appear.js:27]

```
for (var index in selectors) {
```

will include properties from Prototype.  The fix is to use

```
for (var index = 0; index < selectors.length; index++)
```

as selectors is an Array.
