### PR TITLE
prevent unnecessary array length checking

### DIFF
--- a/jquery.appear.js
+++ b/jquery.appear.js
@@ -23,7 +23,7 @@
 
   function process() {
     check_lock = false;
-    for (var index = 0; index < selectors.length; index++) {
+    for (var index = 0, selectorsLength = selectors.length; index < selectorsLength; index++) {
       var $appeared = $(selectors[index]).filter(function() {
         return $(this).is(':appeared');
       });


### PR DESCRIPTION
don't need use length method for each iteration.
