### PR TITLE
Calling appear() on multiple DOM objects caused wrong $disappeared

### DIFF
--- a/jquery.appear.js
+++ b/jquery.appear.js
@@ -34,7 +34,7 @@
         var $disappeared = $prior_appeared.not($appeared);
         $disappeared.trigger('disappear', [$disappeared]);
       }
-      $prior_appeared = $appeared;
+      $prior_appeared.push($appeared);
     }
   }
 


### PR DESCRIPTION
... calculation.

The reason was, that $prior_appeared did not persist correctly on case appear() was called on more that one selector. Simply fixed by making $prior_appeared's to persist by pushing them instead of setting them.
