### PR TITLE
Bug: calling appear() on multiple DOM elements

### DIFF
--- a/jquery.appear.js
+++ b/jquery.appear.js
@@ -34,7 +34,9 @@
         var $disappeared = $prior_appeared.not($appeared);
         $disappeared.trigger('disappear', [$disappeared]);
       }
-      $prior_appeared.push($appeared);
+      if(!!$prior_appeared){
+        $prior_appeared.push($appeared);
+      }
     }
   }
 


### PR DESCRIPTION
In case appear() is called on multiple DOM elements, $prior_appeared did not remember the prior appeared elements for ALL selectors. Thus $disappeared was calculated incorrectly which caused weird behaviour. Fixed by simply pushing prior appeared elements into $prior_appeared, instead resetting $prior_appeared for every selector / jquery element.
