### PR TITLE
Performance improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@
 
 A fork of the plugin on https://github.com/morr/jquery.appear
 
-What changed:
+## What changed:
 
- - removed timeouts. It uses jQuery.debounce plugin instead
- - removed force_process
- - added disappear method in order to remove an element from being observed
+ * removed timeouts. It uses jQuery.debounce plugin instead
+ * removed force_process
+ * added disappear method in order to remove an element from being observed
 
-
- What achieved:
+ ## What achieved:
+ 
  - enchanced performance on many elements
 
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A fork of the plugin on https://github.com/morr/jquery.appear
 What changed:
 
  - removed timeouts. It uses jQuery.debounce plugin instead
- - removed force_process.
+ - removed force_process
  - added disappear method in order to remove an element from being observed
 
 

--- a/README.md
+++ b/README.md
@@ -1,33 +1,15 @@
 # jQuery.appear
 
-This is a total revamp of original jquery.appear plugin hosted on http://code.google.com/p/jquery-appear/
+A fork of the plugin on https://github.com/morr/jquery.appear
 
-Check <a href="http://morr.github.com/appear.html">demo page</a>!
+What changed:
+ - removed timeouts. It uses jQuery.debounce plugin instead
+ - removed force_process.
+ - added disappear method in order to remove an element from being observed
+ 
+ What achieved:
+ - enchanced performance on many elements
 
-This plugin can be used to prevent unnecessary processeing for content that is hidden or is outside of the browser viewport.
-
-It implements a custom *appear*/*disappear* events which are fired when an element became visible/invisible in the browser viewport.
-
-        $('someselector').appear(); // It supports optinal hash with "force_process" and "interval" keys. Check source code for details.
-
-        $('<div>test</div>').appear(); // It also supports raw DOM nodes wrapped in jQuery.
-
-        $('someselector').on('appear', function(event, $all_appeared_elements) {
-          // this element is now inside browser viewport
-        });
-        $('someselector').on('disappear', function(event, $all_disappeared_elements) {
-          // this element is now outside browser viewport
-        });
-
-If you want to fire *appear* event for elements which are close to vieport but are not visible yet, you may add data attributes *appear-top-offset* and *appear-left-offset* to DOM nodes.
-
-        <div class="postloader" data-appear-top-offset="600">...</div> # appear will be fired when an element is below browser viewport for 600 or less pixels
-
-Appear check can be forced by calling *$.force_appear()*. This is suitable in cases when page is in initial state (not scrolled and not resized) and when you want manually trigger appearance check.
-
-Also this plugin provides custom jQuery filter for manual checking element appearance.
-
-        $('someselector').is(':appeared')
 
 # License
 

--- a/README.md
+++ b/README.md
@@ -3,10 +3,12 @@
 A fork of the plugin on https://github.com/morr/jquery.appear
 
 What changed:
+
  - removed timeouts. It uses jQuery.debounce plugin instead
  - removed force_process.
  - added disappear method in order to remove an element from being observed
- 
+
+
  What achieved:
  - enchanced performance on many elements
 

--- a/README.md
+++ b/README.md
@@ -8,9 +8,8 @@ A fork of the plugin on https://github.com/morr/jquery.appear
  * removed force_process
  * added disappear method in order to remove an element from being observed
 
- ## What achieved:
- 
- - enchanced performance on many elements
+## What achieved:
+ * enchanced performance on many elements
 
 
 # License


### PR DESCRIPTION
 Requires jQuery.debounce

Performance improvements:
* removed timeouts. It uses jQuery.debounce plugin instead
* removed force_process
* added disappear method in order to remove an element from being observed