### PR TITLE
Add support for node require

### DIFF
--- a/jquery.appear.js
+++ b/jquery.appear.js
@@ -98,4 +98,11 @@
       return false;
     }
   });
-})(jQuery);
+})(function() {
+  if (typeof module !== 'undefined') {
+    // Node
+    return require('jquery');
+  } else {
+    return jQuery;
+  }
+}());

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "email" : "takandar@gmail.com",
     "url": "https://github.com/morr/jquery.appear/blob/master/AUTHORS.txt"
   },
+  "main": "jquery.appear.js",
   "maintainers": [
     {
       "name": "Andrey Sidorov",


### PR DESCRIPTION
Can now use the library by calling `require('jquery.appear')`, no longer relies on a jQuery global object being present.