### PR TITLE
A bug fix and some efficiency upgrade

### DIFF
--- a/jquery.appear.js
+++ b/jquery.appear.js
@@ -6,7 +6,7 @@
  *
  * https://github.com/morr/jquery.appear/
  *
- * Version: 0.3.4
+ * Version: 0.3.5
  */
 (function($) {
   var selectors = [];
@@ -19,7 +19,7 @@
   }
   var $window = $(window);
 
-  var $prior_appeared;
+  var $prior_appeared = [];
 
   function process() {
     check_lock = false;
@@ -30,11 +30,11 @@
 
       $appeared.trigger('appear', [$appeared]);
 
-      if ($prior_appeared) {
-        var $disappeared = $prior_appeared.not($appeared);
+      if ($prior_appeared[index]) {
+        var $disappeared = $prior_appeared[index].not($appeared);
         $disappeared.trigger('disappear', [$disappeared]);
       }
-      $prior_appeared = $appeared;
+      $prior_appeared[index] = $appeared;
     }
   }
 

--- a/jquery.appear.js
+++ b/jquery.appear.js
@@ -27,16 +27,20 @@
       var $appeared = $(selectors[index]).filter(function() {
         return $(this).is(':appeared');
       });
-
-      $appeared.trigger('appear', [$appeared]);
-
-      if ($prior_appeared[index]) {
-        var $disappeared = $prior_appeared[index].not($appeared);
-        $disappeared.trigger('disappear', [$disappeared]);
+      
+      if (typeof $prior_appeared[index] == 'undefined')
+      {
+        $prior_appeared[index] = $([]);
       }
+
+      var $new_appeared = $appeared.not($prior_appeared[index]);
+      $new_appeared.trigger('appear', [$new_appeared]);
+
+      var $disappeared = $prior_appeared[index].not($appeared);
+      $disappeared.trigger('disappear', [$disappeared]);
+      
       $prior_appeared[index] = $appeared;
     }
-  }
 
   // "appeared" custom filter
   $.expr[':']['appeared'] = function(element) {


### PR DESCRIPTION
I found a bug when running multiple instances of appear for example something like this

	$('.selector1').appear({force_process: true})
	.on('appear', function() {
		console.log('hi 1');
	})
	.on('disappear', function() {
		console.log('bye 1');
	});
	
	$('.selector2').appear({force_process: true})
	.on('appear', function() {
		console.log('hi 2');
	})
	.on('disappear', function() {
		console.log('bye 2');
	});

when scrolled and both selector where visible disappear was triggered for both selectors.

Second fix is for disabling running appear event for elements for which it was already fired.