### PR TITLE
Add check to make sure .appear is only called once when element stays in view.

### DIFF
--- a/jquery.appear.js
+++ b/jquery.appear.js
@@ -6,7 +6,7 @@
  *
  * https://github.com/morr/jquery.appear/
  *
- * Version: 0.3.6
+ * Version: 0.3.7
  */
 (function($) {
   var selectors = [];

--- a/jquery.appear.js
+++ b/jquery.appear.js
@@ -20,6 +20,7 @@
   var $window = $(window);
 
   var $prior_appeared = [];
+  var $in_view = [];
 
   function appeared(selector) {
     return $(selector).filter(function() {
@@ -32,11 +33,17 @@
     for (var index = 0, selectorsLength = selectors.length; index < selectorsLength; index++) {
       var $appeared = appeared(selectors[index]);
 
-      $appeared.trigger('appear', [$appeared]);
+      if ($appeared.length && $in_view[index] !== true){
+        $appeared.trigger('appear', [$appeared]);
+        $in_view[index] = true;
+      }
 
       if ($prior_appeared[index]) {
         var $disappeared = $prior_appeared[index].not($appeared);
-        $disappeared.trigger('disappear', [$disappeared]);
+        if ($disappeared.length) {
+            $disappeared.trigger('disappear', [$disappeared]);
+            $in_view[index] = false;
+        }
       }
       $prior_appeared[index] = $appeared;
     }

--- a/jquery.appear.js
+++ b/jquery.appear.js
@@ -8,6 +8,7 @@
  *
  * Version: 0.3.7
  */
+
 (function($) {
   var selectors = [];
 
@@ -55,27 +56,29 @@
   }
 
   // "appeared" custom filter
-  $.expr[':'].appeared = function(element) {
-    var $element = $(element);
-    if (!$element.is(':visible')) {
-      return false;
-    }
+  $.expr.pseudos.appeared = $.expr.createPseudo(function(arg) {
+    return function(element) {
+      var $element = $(element);
+      if (!$element.is(':visible')) {
+        return false;
+      }
 
-    var window_left = $window.scrollLeft();
-    var window_top = $window.scrollTop();
-    var offset = $element.offset();
-    var left = offset.left;
-    var top = offset.top;
+      var window_left = $window.scrollLeft();
+      var window_top = $window.scrollTop();
+      var offset = $element.offset();
+      var left = offset.left;
+      var top = offset.top;
 
-    if (top + $element.height() >= window_top &&
-        top - ($element.data('appear-top-offset') || 0) <= window_top + $window.height() &&
-        left + $element.width() >= window_left &&
-        left - ($element.data('appear-left-offset') || 0) <= window_left + $window.width()) {
-      return true;
-    } else {
-      return false;
+      if (top + $element.height() >= window_top &&
+          top - ($element.data('appear-top-offset') || 0) <= window_top + $window.height() &&
+          left + $element.width() >= window_left &&
+          left - ($element.data('appear-left-offset') || 0) <= window_left + $window.width()) {
+        return true;
+      } else {
+        return false;
+      }
     }
-  };
+  });
 
   $.fn.extend({
     // watching for element's appearance in browser viewport


### PR DESCRIPTION
I need something to fire a settimeout when item appears, but 0.3.6 fires that every time you scroll with it in view too. This keeps track of if the element is in view and has appeared, and only triggers appear once, until the element disappears.